### PR TITLE
[refact] Optimize the usage of cv::matchTemplate to improve speed

### DIFF
--- a/vop2el_src/test/Volp2elParameters.ini
+++ b/vop2el_src/test/Volp2elParameters.ini
@@ -37,7 +37,8 @@ tukey_parameter = 1.0
 [vop2el_matcher_parameters]
 ; Maximum number of matches used to compute relative pose, -1 to compute and use all matches
 max_number_matches = -1
-; Normalized cross-correlation score above which the match is considered valid
+; Normalized cross-correlation score above which the match is considered valid,
+; The best results were achieved with ncc_threshold values ranging from 0.7 to 0.75
 ncc_treshold = 0.7
 ; Interval of search on the epipolar line, depends on the speed of the robot
 epipolar_line_search_interval = 100


### PR DESCRIPTION
Goal : 

- Improve performance and documentation

Changes:
- Feat: 
     - Optimize the usage of cv::matchTemplate to improve performance
- Doc:
     - Improve comment of ncc_treshold parameter