### PR TITLE
[refact] improve performance of Vop2el matcher

### DIFF
--- a/vop2el_src/vop2el_lib/include/Vop2elMatcher.h
+++ b/vop2el_src/vop2el_lib/include/Vop2elMatcher.h
@@ -115,11 +115,15 @@ class Vop2elMatcher
         // Compute normalized cross-correlation of a patch from reference image
         // on the epipolar line of target image
         void ComputeNccOnEpipolarLine(const cv::Mat& referencePatch,
-                                    const cv::Mat& targetImage,
                                     PatchType patchType,
-                                    const cv::Point2f& KeyPoint,
-                                    const cv::Vec3f& epipolarLine,
+                                    const cv::Mat& candidatePatches,
                                     std::vector<PatchWithScore>& matches) const;
+        // Compute valid candidates patches on epipolar line
+        void ComputeCandidatesOnEpipolarLine(const cv::Mat& targetImage,
+                                            const cv::Point2f& keyPoint,
+                                            const cv::Vec3f& epipolarLine,
+                                            std::vector<PatchWithScore>& matches,
+                                            cv::Mat& candidatePatches) const;
         // Check whether the difference between the highest and the lowest ncc score
         // is bigger than a threshold which means that the keypoint is not ambigious
         bool IsNumberOfCandidateValid(const std::vector<PatchWithScore>& matches) const;

--- a/vop2el_src/vop2el_lib/src/Vop2elMatcher.cpp
+++ b/vop2el_src/vop2el_lib/src/Vop2elMatcher.cpp
@@ -408,18 +408,14 @@ void Vop2elMatcher::GetMatchPreviousFrameOriginal(const cv::Mat& referencePatch,
 
     cv::Point2f triangProjectedPreviousRightPoint(static_cast<float>(triangProjectedPreviousRight.at<double>(0)),
                                                 static_cast<float>(triangProjectedPreviousRight.at<double>(1)));
-    std::pair<cv::Point2f, float> candidateMatchPreviousLeft;
     this->SearchMatchesPreviousFrame(referencePatch, *this->PairWithKeyPoints.PreviousLeftImage,
-                                    triangProjectedPreviousLeftPoint, candidateMatchPreviousLeft);
+                                    triangProjectedPreviousLeftPoint, bestKeyPointPreviousLeft);
 
-    bestKeyPointPreviousLeft = std::move(candidateMatchPreviousLeft);
+    if ((bestKeyPointPreviousLeft.second <= this->Vop2elMatcherParams.NccTreshold))
+        return;
 
-    std::pair<cv::Point2f, float> candidateMatchPreviousRight;
     this->SearchMatchesPreviousFrame(referencePatch, *this->PairWithKeyPoints.PreviousRightImage,
-                                    triangProjectedPreviousRightPoint, candidateMatchPreviousRight);
-
-    bestKeyPointPreviousRight = std::move(candidateMatchPreviousRight);
-
+                                    triangProjectedPreviousRightPoint, bestKeyPointPreviousRight);
 }
 
 //---------------------------------------------------------------------------------------
@@ -434,20 +430,16 @@ void Vop2elMatcher::GetMatchPreviousFrameCorrected(const cv::Mat& correctedPatch
 
     cv::Point2f reprojectedKeyPointPreviousLeft;
     this->CorrectorActualRightPreviousLeft->GetKeyPointByPlaneProjection(keyPointActual, reprojectedKeyPointPreviousLeft);
-
-    std::pair<cv::Point2f, float> optimalMatchPreviousLeft;
     this->SearchMatchesPreviousFrame(correctedPatchPreviousLeft, *this->PairWithKeyPoints.PreviousLeftImage,
-                                    reprojectedKeyPointPreviousLeft, optimalMatchPreviousLeft);
-    bestKeyPointPreviousLeft = std::move(optimalMatchPreviousLeft);
+                                    reprojectedKeyPointPreviousLeft, bestKeyPointPreviousLeft);
+
+    if ((bestKeyPointPreviousLeft.second <= this->Vop2elMatcherParams.NccTreshold))
+        return;
 
     cv::Point2f reprojectedKeyPointPreviousRight;
     this->CorrectorActualRightPreviousRight->GetKeyPointByPlaneProjection(keyPointActual, reprojectedKeyPointPreviousRight);
-
-
-    std::pair<cv::Point2f, float> optimalMatchPreviousRight;
     this->SearchMatchesPreviousFrame(correctedPatchPreviousRight, *this->PairWithKeyPoints.PreviousRightImage,
-                                    reprojectedKeyPointPreviousRight, optimalMatchPreviousRight);
-    bestKeyPointPreviousRight = std::move(optimalMatchPreviousRight);
+                                    reprojectedKeyPointPreviousRight, bestKeyPointPreviousRight);
 }
 
 //---------------------------------------------------------------------------------------

--- a/vop2el_src/vop2el_lib/src/Vop2elMatcher.cpp
+++ b/vop2el_src/vop2el_lib/src/Vop2elMatcher.cpp
@@ -516,7 +516,7 @@ void Vop2elMatcher::GetMatches(std::vector<Vop2el::Match>& matches)
     int numCorrected = 0;
     bool doContinue = true;
 
-    #pragma omp parallel for
+    #pragma omp parallel for schedule(dynamic)
     for (int keyPointIdx = 0; keyPointIdx < this->PairWithKeyPoints.ActualLeftKeyPoints->size(); ++keyPointIdx)
     {
         if (doContinue)


### PR DESCRIPTION
Goal : 

- Improve performance of Vop2el matcher

Changes:
- Refact: 
     - Skip computing NCC score of previous right when previous left is unvalid
     - Enable dynamic scheduling for the OpenMP matcher for loop
     - Improve time of search on epipolar line